### PR TITLE
General updates for the existing analysis and dockerize templates

### DIFF
--- a/templates/analysis.mvn.yml
+++ b/templates/analysis.mvn.yml
@@ -65,7 +65,7 @@ steps:
   inputs:
     channelId: ${{ parameters.discordChannel }}
     webhookKey: ${{ parameters.discordKey }}
-    name: $(System.TeamProject) - Analysis
+    name: '$(System.TeamProject) - $(Build.BuildId)'
     avatar: 'https://avatars2.githubusercontent.com/u/39168408?s=460&v=4'
     messageType: 'content'
     content: | 
@@ -84,11 +84,11 @@ steps:
   inputs:
     channelId: ${{ parameters.discordChannel }}
     webhookKey: ${{ parameters.discordKey }}
-    name: $(System.TeamProject) - PR Analysis
+    name: '$(System.TeamProject) - $(Build.BuildId)'
     avatar: 'https://github.com/jpbulloch5/jpbulloch5.github.io/blob/main/GitHubPR.png?raw=true'
     messageType: 'content'
     content: | 
-      **__Analysis Report__**
+      **__PR Analysis Report__**
       **Status:** $(Agent.JobStatus)
       **Report:** <${{ parameters.sonarUrlPrefix }}$(Build.SourceBranch)&id=${{ parameters.sonarKeyPrefix }}${{ parameters.microservice }}>
       **Logs:** <$(System.CollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&view=logs>

--- a/templates/analysis.mvn.yml
+++ b/templates/analysis.mvn.yml
@@ -85,7 +85,7 @@ steps:
     channelId: ${{ parameters.discordChannel }}
     webhookKey: ${{ parameters.discordKey }}
     name: $(System.TeamProject) - PR Analysis
-    avatar: 'https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse3.mm.bing.net%2Fth%3Fid%3DOIP.t57fZPkb6fBVhHUXII8DSAHaHa%26pid%3DApi&f=1'
+    avatar: 'https://github.com/jpbulloch5/jpbulloch5.github.io/blob/main/GitHubPR.png?raw=true'
     messageType: 'content'
     content: | 
       **__Analysis Report__**

--- a/templates/analysis.mvn.yml
+++ b/templates/analysis.mvn.yml
@@ -65,7 +65,7 @@ steps:
   inputs:
     channelId: ${{ parameters.discordChannel }}
     webhookKey: ${{ parameters.discordKey }}
-    name: '$(System.TeamProject) - $(Build.BuildId)'
+    name: '$(System.TeamProject) Analysis - $(Build.BuildId)'
     avatar: 'https://avatars2.githubusercontent.com/u/39168408?s=460&v=4'
     messageType: 'content'
     content: | 
@@ -84,7 +84,7 @@ steps:
   inputs:
     channelId: ${{ parameters.discordChannel }}
     webhookKey: ${{ parameters.discordKey }}
-    name: '$(System.TeamProject) - $(Build.BuildId)'
+    name: '$(System.TeamProject) PR Analysis - $(Build.BuildId)'
     avatar: 'https://github.com/jpbulloch5/jpbulloch5.github.io/blob/main/GitHubPR.png?raw=true'
     messageType: 'content'
     content: | 

--- a/templates/analysis.ng.yml
+++ b/templates/analysis.ng.yml
@@ -68,11 +68,11 @@ steps:
   inputs:
     channelId: ${{ parameters.discordChannel }}
     webhookKey: ${{ parameters.discordKey }}
-    name: $(System.TeamProject) - Analysis
+    name: $(System.TeamProject) - $(Build.BuildId)
     avatar: 'https://avatars2.githubusercontent.com/u/39168408?s=460&v=4'
     messageType: 'content'
     content: | 
-      **__Analysis Report__**
+      **__PR Analysis Report__**
       **Status:** $(Agent.JobStatus)
       **Branch:** $(Build.SourceBranch)
       **Trigger:** $(Build.Reason)
@@ -87,7 +87,7 @@ steps:
   inputs:
     channelId: ${{ parameters.discordChannel }}
     webhookKey: ${{ parameters.discordKey }}
-    name: $(System.TeamProject) - PR Analysis
+    name: $(System.TeamProject) - $(Build.BuildId)
     avatar: 'https://github.com/jpbulloch5/jpbulloch5.github.io/blob/main/GitHubPR.png?raw=true'
     messageType: 'content'
     content: | 

--- a/templates/analysis.ng.yml
+++ b/templates/analysis.ng.yml
@@ -88,7 +88,7 @@ steps:
     channelId: ${{ parameters.discordChannel }}
     webhookKey: ${{ parameters.discordKey }}
     name: $(System.TeamProject) - PR Analysis
-    avatar: 'https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse3.mm.bing.net%2Fth%3Fid%3DOIP.t57fZPkb6fBVhHUXII8DSAHaHa%26pid%3DApi&f=1'
+    avatar: 'https://github.com/jpbulloch5/jpbulloch5.github.io/blob/main/GitHubPR.png?raw=true'
     messageType: 'content'
     content: | 
       **__Analysis Report__**

--- a/templates/analysis.ng.yml
+++ b/templates/analysis.ng.yml
@@ -49,6 +49,7 @@ steps:
 
 # this step is pending fixes from Andrew, or the devs
 - script: npx ng test --browsers ChromeHeadless --no-watch --code-coverage
+  continueOnError: true
   workingDirectory: ${{ parameters.workDir }}
   displayName: Test ${{ parameters.microservice }} --> Task
 
@@ -65,8 +66,8 @@ steps:
 - task: 'ado-discord-webhook@1' # <-- See external requirements note above
   condition: and(always(), ne(variables['Build.Reason'],'PullRequest'))
   inputs:
-    channelId: $(discordAnalysisChannel)
-    webhookKey: $(discordAnalysisKey)
+    channelId: ${{ parameters.discordChannel }}
+    webhookKey: ${{ parameters.discordKey }}
     name: $(System.TeamProject) - Analysis
     avatar: 'https://avatars2.githubusercontent.com/u/39168408?s=460&v=4'
     messageType: 'content'
@@ -84,10 +85,10 @@ steps:
 - task: 'ado-discord-webhook@1' # <-- See external requirements note above
   condition: and(always(), eq(variables['Build.Reason'],'PullRequest'))
   inputs:
-    channelId: $(discordAnalysisChannel)
-    webhookKey: $(discordAnalysisKey)
+    channelId: ${{ parameters.discordChannel }}
+    webhookKey: ${{ parameters.discordKey }}
     name: $(System.TeamProject) - PR Analysis
-    avatar: 'https://raw.githubusercontent.com/jpbulloch5/jpbulloch5.github.io/main/GitHubPR.png'
+    avatar: 'https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse3.mm.bing.net%2Fth%3Fid%3DOIP.t57fZPkb6fBVhHUXII8DSAHaHa%26pid%3DApi&f=1'
     messageType: 'content'
     content: | 
       **__Analysis Report__**

--- a/templates/analysis.ng.yml
+++ b/templates/analysis.ng.yml
@@ -88,7 +88,7 @@ steps:
     channelId: $(discordAnalysisChannel)
     webhookKey: $(discordAnalysisKey)
     name: $(System.TeamProject) - PR Analysis
-    avatar: 'https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse3.mm.bing.net%2Fth%3Fid%3DOIP.t57fZPkb6fBVhHUXII8DSAHaHa%26pid%3DApi&f=1'
+    avatar: 'https://github.com/jpbulloch5/jpbulloch5.github.io/blob/main/GitHubPR.png?raw=true'
     messageType: 'content'
     content: | 
       **__Analysis Report__**

--- a/templates/analysis.ng.yml
+++ b/templates/analysis.ng.yml
@@ -68,7 +68,7 @@ steps:
   inputs:
     channelId: ${{ parameters.discordChannel }}
     webhookKey: ${{ parameters.discordKey }}
-    name: $(System.TeamProject) - $(Build.BuildId)
+    name: $(System.TeamProject) PR Analysis - $(Build.BuildId)
     avatar: 'https://avatars2.githubusercontent.com/u/39168408?s=460&v=4'
     messageType: 'content'
     content: | 
@@ -87,7 +87,7 @@ steps:
   inputs:
     channelId: ${{ parameters.discordChannel }}
     webhookKey: ${{ parameters.discordKey }}
-    name: $(System.TeamProject) - $(Build.BuildId)
+    name: $(System.TeamProject) Analysis - $(Build.BuildId)
     avatar: 'https://github.com/jpbulloch5/jpbulloch5.github.io/blob/main/GitHubPR.png?raw=true'
     messageType: 'content'
     content: | 

--- a/templates/analysis.ng.yml
+++ b/templates/analysis.ng.yml
@@ -87,7 +87,7 @@ steps:
     channelId: $(discordAnalysisChannel)
     webhookKey: $(discordAnalysisKey)
     name: $(System.TeamProject) - PR Analysis
-    avatar: 'https://github.com/jpbulloch5/jpbulloch5.github.io/blob/main/GitHubPR.png?raw=true'
+    avatar: 'https://raw.githubusercontent.com/jpbulloch5/jpbulloch5.github.io/main/GitHubPR.png'
     messageType: 'content'
     content: | 
       **__Analysis Report__**

--- a/templates/analysis.ng.yml
+++ b/templates/analysis.ng.yml
@@ -68,11 +68,11 @@ steps:
   inputs:
     channelId: ${{ parameters.discordChannel }}
     webhookKey: ${{ parameters.discordKey }}
-    name: $(System.TeamProject) PR Analysis - $(Build.BuildId)
+    name: $(System.TeamProject) Analysis - $(Build.BuildId)
     avatar: 'https://avatars2.githubusercontent.com/u/39168408?s=460&v=4'
     messageType: 'content'
     content: | 
-      **__PR Analysis Report__**
+      **__Analysis Report__**
       **Status:** $(Agent.JobStatus)
       **Branch:** $(Build.SourceBranch)
       **Trigger:** $(Build.Reason)
@@ -87,11 +87,11 @@ steps:
   inputs:
     channelId: ${{ parameters.discordChannel }}
     webhookKey: ${{ parameters.discordKey }}
-    name: $(System.TeamProject) Analysis - $(Build.BuildId)
+    name: $(System.TeamProject) PR Analysis - $(Build.BuildId)
     avatar: 'https://github.com/jpbulloch5/jpbulloch5.github.io/blob/main/GitHubPR.png?raw=true'
     messageType: 'content'
     content: | 
-      **__Analysis Report__**
+      **__PR Analysis Report__**
       **Status:** $(Agent.JobStatus)
       **Report:** <${{ parameters.sonarUrlPrefix }}$(Build.SourceBranch)&id=${{ parameters.sonarKeyPrefix }}${{ parameters.microservice }}>
       **Logs:** <$(System.CollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&view=logs>

--- a/templates/analysis.ng.yml
+++ b/templates/analysis.ng.yml
@@ -49,7 +49,6 @@ steps:
 
 # this step is pending fixes from Andrew, or the devs
 - script: npx ng test --browsers ChromeHeadless --no-watch --code-coverage
-  continueOnError: true
   workingDirectory: ${{ parameters.workDir }}
   displayName: Test ${{ parameters.microservice }} --> Task
 

--- a/templates/dockerize.mvn.yml
+++ b/templates/dockerize.mvn.yml
@@ -14,6 +14,7 @@ parameters:
   type: string                      #     with the above repo
 - name: containerUrl                # <-- URL to the associated repo
   type: string
+  default: "public link unavailable"
 - name: version                     # <-- you should only use this parameter if the value of
   type: string                      #     useDynamicVersion is set to false, otherwise it is 
   default: undefined                #     overwritten dynamically using mvn-version-1.2.1

--- a/templates/dockerize.mvn.yml
+++ b/templates/dockerize.mvn.yml
@@ -62,7 +62,7 @@ steps:
     inputs:
       channelId: ${{ parameters.discordChannel }}
       webhookKey: ${{ parameters.discordKey }}
-      name: '$(System.TeamProject) - Docker'
+      name: '$(System.TeamProject) - $(Build.BuildId)'
       avatar: 'https://about.gitlab.com/images/devops-tools/azure-cr-logo.png'
       messageType: 'content'
       content: |
@@ -92,7 +92,7 @@ steps:
     inputs:
       channelId: ${{ parameters.discordChannel }}
       webhookKey: ${{ parameters.discordKey }}
-      name: '$(System.TeamProject) - Docker'
+      name: '$(System.TeamProject) - $(Build.BuildId)'
       avatar: 'https://about.gitlab.com/images/devops-tools/azure-cr-logo.png'
       messageType: 'content'
       content: |

--- a/templates/dockerize.mvn.yml
+++ b/templates/dockerize.mvn.yml
@@ -62,7 +62,7 @@ steps:
     inputs:
       channelId: ${{ parameters.discordChannel }}
       webhookKey: ${{ parameters.discordKey }}
-      name: '$(System.TeamProject) - $(Build.BuildId)'
+      name: '$(System.TeamProject) Dockerize - $(Build.BuildId)'
       avatar: 'https://about.gitlab.com/images/devops-tools/azure-cr-logo.png'
       messageType: 'content'
       content: |
@@ -92,7 +92,7 @@ steps:
     inputs:
       channelId: ${{ parameters.discordChannel }}
       webhookKey: ${{ parameters.discordKey }}
-      name: '$(System.TeamProject) - $(Build.BuildId)'
+      name: '$(System.TeamProject) Dockerize - $(Build.BuildId)'
       avatar: 'https://about.gitlab.com/images/devops-tools/azure-cr-logo.png'
       messageType: 'content'
       content: |

--- a/templates/dockerize.mvn.yml
+++ b/templates/dockerize.mvn.yml
@@ -62,7 +62,7 @@ steps:
       channelId: ${{ parameters.discordChannel }}
       webhookKey: ${{ parameters.discordKey }}
       name: '$(System.TeamProject) - Docker'
-      avatar: 'https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fcdn3.iconfinder.com%2Fdata%2Ficons%2Flogos-and-brands-adobe%2F512%2F97_Docker-512.png&f=1&nofb=1'
+      avatar: 'https://about.gitlab.com/images/devops-tools/azure-cr-logo.png'
       messageType: 'content'
       content: |
         **__Dockerization Report__**
@@ -92,7 +92,7 @@ steps:
       channelId: ${{ parameters.discordChannel }}
       webhookKey: ${{ parameters.discordKey }}
       name: '$(System.TeamProject) - Docker'
-      avatar: 'https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fcdn3.iconfinder.com%2Fdata%2Ficons%2Flogos-and-brands-adobe%2F512%2F97_Docker-512.png&f=1&nofb=1'
+      avatar: 'https://about.gitlab.com/images/devops-tools/azure-cr-logo.png'
       messageType: 'content'
       content: |
         **__Dockerization Report__**

--- a/templates/dockerize.mvn.yml
+++ b/templates/dockerize.mvn.yml
@@ -50,7 +50,7 @@ steps:
   - task: Docker@2
     inputs:
       containerRegistry: ${{ parameters.containerServiceConnection }}
-      repository: '${{ parameters.containerRepo }}/${{ parameters.imageName }}'
+      repository: '${{ parameters.imageName }}'
       command: 'buildAndPush'
       Dockerfile: '**/Dockerfile'
       tags: '$(version)'

--- a/templates/dockerize.ng.yml
+++ b/templates/dockerize.ng.yml
@@ -47,8 +47,8 @@ steps:
   - task: ado-discord-webhook@1
     condition: always()
     inputs:
-      channelId: $(discordDockerChannel)
-      webhookKey: $(discordDockerKey)
+      channelId: $(discordChannel)
+      webhookKey: $(discordKey)
       name: '$(System.TeamProject) Dockerize - $(Build.BuildId)'
       avatar: 'https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fcdn3.iconfinder.com%2Fdata%2Ficons%2Flogos-and-brands-adobe%2F512%2F97_Docker-512.png&f=1&nofb=1'
       messageType: 'content'
@@ -77,8 +77,8 @@ steps:
     - task: ado-discord-webhook@1
       condition: always()
       inputs:
-        channelId: $(discordDockerChannel)
-        webhookKey: $(discordDockerKey)
+        channelId: $(discordChannel)
+        webhookKey: $(discordKey)
         name: '$(System.TeamProject) Dockerize - $(Build.BuildId)'
         avatar: 'https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fcdn3.iconfinder.com%2Fdata%2Ficons%2Flogos-and-brands-adobe%2F512%2F97_Docker-512.png&f=1&nofb=1'
         messageType: 'content'

--- a/templates/dockerize.ng.yml
+++ b/templates/dockerize.ng.yml
@@ -49,7 +49,7 @@ steps:
     inputs:
       channelId: $(discordDockerChannel)
       webhookKey: $(discordDockerKey)
-      name: '$(System.TeamProject) - Docker'
+      name: '$(System.TeamProject) - $(Build.BuildId)'
       avatar: 'https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fcdn3.iconfinder.com%2Fdata%2Ficons%2Flogos-and-brands-adobe%2F512%2F97_Docker-512.png&f=1&nofb=1'
       messageType: 'content'
       content: |
@@ -79,7 +79,7 @@ steps:
       inputs:
         channelId: $(discordDockerChannel)
         webhookKey: $(discordDockerKey)
-        name: '$(System.TeamProject) - Docker'
+        name: '$(System.TeamProject) - $(Build.BuildId)'
         avatar: 'https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fcdn3.iconfinder.com%2Fdata%2Ficons%2Flogos-and-brands-adobe%2F512%2F97_Docker-512.png&f=1&nofb=1'
         messageType: 'content'
         content: |

--- a/templates/dockerize.ng.yml
+++ b/templates/dockerize.ng.yml
@@ -47,8 +47,8 @@ steps:
   - task: ado-discord-webhook@1
     condition: always()
     inputs:
-      channelId: $(discordChannel)
-      webhookKey: $(discordKey)
+      channelId: ${{ parameters.discordChannel }}
+      webhookKey: ${{ parameters.discordKey }}
       name: '$(System.TeamProject) Dockerize - $(Build.BuildId)'
       avatar: 'https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fcdn3.iconfinder.com%2Fdata%2Ficons%2Flogos-and-brands-adobe%2F512%2F97_Docker-512.png&f=1&nofb=1'
       messageType: 'content'
@@ -77,8 +77,8 @@ steps:
     - task: ado-discord-webhook@1
       condition: always()
       inputs:
-        channelId: $(discordChannel)
-        webhookKey: $(discordKey)
+        channelId: ${{ parameters.discordChannel }}
+        webhookKey: ${{ parameters.discordKey }}
         name: '$(System.TeamProject) Dockerize - $(Build.BuildId)'
         avatar: 'https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fcdn3.iconfinder.com%2Fdata%2Ficons%2Flogos-and-brands-adobe%2F512%2F97_Docker-512.png&f=1&nofb=1'
         messageType: 'content'

--- a/templates/dockerize.ng.yml
+++ b/templates/dockerize.ng.yml
@@ -7,6 +7,7 @@ parameters:
   type: string                      #     with the above repo
 - name: containerUrl                # <-- URL to the associated repo
   type: string
+  default: "public link unavailable"
 - name: version                     # <-- you should only use this parameter if the value of
   type: string                      #     useDynamicVersion is set to false, otherwise it is 
   default: undefined                #     overwritten dynamically from package.json using a script

--- a/templates/dockerize.ng.yml
+++ b/templates/dockerize.ng.yml
@@ -50,7 +50,7 @@ steps:
       channelId: ${{ parameters.discordChannel }}
       webhookKey: ${{ parameters.discordKey }}
       name: '$(System.TeamProject) Dockerize - $(Build.BuildId)'
-      avatar: 'https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fcdn3.iconfinder.com%2Fdata%2Ficons%2Flogos-and-brands-adobe%2F512%2F97_Docker-512.png&f=1&nofb=1'
+      avatar: 'https://about.gitlab.com/images/devops-tools/azure-cr-logo.png'
       messageType: 'content'
       content: |
         **__Dockerization Report__**
@@ -80,7 +80,7 @@ steps:
         channelId: ${{ parameters.discordChannel }}
         webhookKey: ${{ parameters.discordKey }}
         name: '$(System.TeamProject) Dockerize - $(Build.BuildId)'
-        avatar: 'https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fcdn3.iconfinder.com%2Fdata%2Ficons%2Flogos-and-brands-adobe%2F512%2F97_Docker-512.png&f=1&nofb=1'
+        avatar: 'https://about.gitlab.com/images/devops-tools/azure-cr-logo.png'
         messageType: 'content'
         content: |
           **__Dockerization Report__**

--- a/templates/dockerize.ng.yml
+++ b/templates/dockerize.ng.yml
@@ -49,7 +49,7 @@ steps:
     inputs:
       channelId: $(discordDockerChannel)
       webhookKey: $(discordDockerKey)
-      name: '$(System.TeamProject) - $(Build.BuildId)'
+      name: '$(System.TeamProject) Dockerize - $(Build.BuildId)'
       avatar: 'https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fcdn3.iconfinder.com%2Fdata%2Ficons%2Flogos-and-brands-adobe%2F512%2F97_Docker-512.png&f=1&nofb=1'
       messageType: 'content'
       content: |
@@ -79,7 +79,7 @@ steps:
       inputs:
         channelId: $(discordDockerChannel)
         webhookKey: $(discordDockerKey)
-        name: '$(System.TeamProject) - $(Build.BuildId)'
+        name: '$(System.TeamProject) Dockerize - $(Build.BuildId)'
         avatar: 'https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fcdn3.iconfinder.com%2Fdata%2Ficons%2Flogos-and-brands-adobe%2F512%2F97_Docker-512.png&f=1&nofb=1'
         messageType: 'content'
         content: |


### PR DESCRIPTION
Some updates are largely cosmetic in nature.

The most important updates relate to fixing the variable formatting of the notifications in the template that were discovered when we moved from the batch test server to a server we intend to share with the developers.

These templates are currently being used by the following pull requests:
https://github.com/1053-August-Duet-Project-Registry/project-registry-frontend/pull/3
https://github.com/1053-August-Duet-Project-Registry/project-registry-gateway/pull/6
https://github.com/1053-August-Duet-Project-Registry/project-registry-tracking-microservice/pull/4
https://github.com/1053-August-Duet-Project-Registry/project-registry-account-microservice/pull/4
https://github.com/1053-August-Duet-Project-Registry/project-registry-project-microservice/pull/3