### PR TITLE
Update azure-pipelines.yml for Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,7 @@ steps:
 - task: KubernetesManifest@0
   inputs:
     action: 'createSecret'
-    kubernetesServiceConnection: ${{ variables.k8sServiceConnection }}
+    kubernetesServiceConnection: ${{ parameters.k8sServiceConnection }}
     namespace: ${{ variables.namespace }}
     secretType: 'dockerRegistry'
     secretName: 'acr-secret'
@@ -42,7 +42,7 @@ steps:
 - task: KubernetesManifest@0
   inputs:
     action: 'deploy'
-    kubernetesServiceConnection: ${{ variables.k8sServiceConnection }}
+    kubernetesServiceConnection: ${{ parameters.k8sServiceConnection }}
     namespace: ${{ variables.namespace }}
     manifests: ${{ variables.prereqManifestPath }}
   displayName: initialize cluster prerequisites
@@ -50,7 +50,7 @@ steps:
 - task: KubernetesManifest@0
   inputs:
     action: 'deploy'
-    kubernetesServiceConnection: ${{ variables.k8sServiceConnection }}
+    kubernetesServiceConnection: ${{ parameters.k8sServiceConnection }}
     namespace: ${{ variables.namespace }}
     manifests: ${{ variables.microserviceManifestPath }}
   displayName: initialize cluster microservices

--- a/templates/analysis.mvn.yml
+++ b/templates/analysis.mvn.yml
@@ -74,7 +74,7 @@ steps:
       **Branch:** $(Build.SourceBranch)
       **Trigger:** $(Build.Reason)
       **Message:** $(Build.SourceVersionMessage)
-      **Report:** <${{ parameters.sonarUrlPrefix }}$(Build.SourceBranch)&id=${{ parameters.sonarKeyPrefix }}${{ parameters.microservice }}>
+      **Report:** <${{ parameters.sonarUrlPrefix }}$(Build.SourceBranchName)&id=${{ parameters.sonarKeyPrefix }}${{ parameters.microservice }}>
       **Logs:** <$(System.CollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&view=logs>
       **Repo:** <$(Build.Repository.Uri)/tree/$(Build.SourceBranchName)>
   displayName: Notification --> Task
@@ -90,7 +90,7 @@ steps:
     content: | 
       **__PR Analysis Report__**
       **Status:** $(Agent.JobStatus)
-      **Report:** <${{ parameters.sonarUrlPrefix }}$(Build.SourceBranch)&id=${{ parameters.sonarKeyPrefix }}${{ parameters.microservice }}>
+      **Report:** <${{ parameters.sonarUrlPrefix }}$(System.PullRequest.SourceBranch)&id=${{ parameters.sonarKeyPrefix }}${{ parameters.microservice }}>
       **Logs:** <$(System.CollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&view=logs>
       **Source:** <$(Build.Repository.Uri)/tree/$(System.PullRequest.SourceBranch)>
       **Target:** <$(Build.Repository.Uri)/tree/$(System.PullRequest.TargetBranch)>

--- a/templates/analysis.ng.yml
+++ b/templates/analysis.ng.yml
@@ -77,7 +77,7 @@ steps:
       **Branch:** $(Build.SourceBranch)
       **Trigger:** $(Build.Reason)
       **Message:** $(Build.SourceVersionMessage)
-      **Report:** <${{ parameters.sonarUrlPrefix }}$(Build.SourceBranch)&id=${{ parameters.sonarKeyPrefix }}${{ parameters.microservice }}>
+      **Report:** <${{ parameters.sonarUrlPrefix }}$(Build.SourceBranchName)&id=${{ parameters.sonarKeyPrefix }}${{ parameters.microservice }}>
       **Logs:** <$(System.CollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&view=logs>
       **Repo:** <$(Build.Repository.Uri)/tree/$(Build.SourceBranchName)>
   displayName: Notification --> Task
@@ -93,7 +93,7 @@ steps:
     content: | 
       **__PR Analysis Report__**
       **Status:** $(Agent.JobStatus)
-      **Report:** <${{ parameters.sonarUrlPrefix }}$(Build.SourceBranch)&id=${{ parameters.sonarKeyPrefix }}${{ parameters.microservice }}>
+      **Report:** <${{ parameters.sonarUrlPrefix }}$(System.PullRequest.SourceBranch)&id=${{ parameters.sonarKeyPrefix }}${{ parameters.microservice }}>
       **Logs:** <$(System.CollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&view=logs>
       **Source:** <$(Build.Repository.Uri)/tree/$(System.PullRequest.SourceBranch)>
       **Target:** <$(Build.Repository.Uri)/tree/$(System.PullRequest.TargetBranch)>


### PR DESCRIPTION
Updating the variable for AKS service connection to a parameter had some overlooked places where it was still formatted as `variables.` instead of `parameters.`

This pertains to the initialize cluster pipeline.

Additionally, I found that the analysis notification links somehow became broken so that the link to sonarCloud was not working, so I am adding those fixes in this PR as well.