### PR TITLE
Lowered resource limits, creating space for istio sidecars

### DIFF
--- a/k8s/microservices/account.yml
+++ b/k8s/microservices/account.yml
@@ -18,11 +18,11 @@ spec:
         image: 'may24devopscontainers.azurecr.io/project-registry-account-microservice:0.0.1-SNAPSHOT'
         resources:
           requests:
-            memory: "1024Mi"
-            cpu: "375m"
+            memory: "850Mi"
+            cpu: "175m"
           limits:
-            memory: "1500Mi"
-            cpu: "400m"
+            memory: "1024Mi"
+            cpu: "200m"
         ports:
         - containerPort: 8081
         env:

--- a/k8s/microservices/gateway.yml
+++ b/k8s/microservices/gateway.yml
@@ -18,11 +18,11 @@ spec:
         image: 'may24devopscontainers.azurecr.io/project-registry-gateway:0.0.1-SNAPSHOT'
         resources:
           requests:
-            memory: "1024Mi"
-            cpu: "375m"
+            memory: "850Mi"
+            cpu: "175m"
           limits:
-            memory: "1500Mi"
-            cpu: "400m"
+            memory: "1024Mi"
+            cpu: "225m"
         ports:
         - containerPort: 8085
         env:

--- a/k8s/microservices/project.yml
+++ b/k8s/microservices/project.yml
@@ -18,11 +18,11 @@ spec:
         image: 'may24devopscontainers.azurecr.io/project-registry-project-microservice:0.0.1-SNAPSHOT'
         resources:
           requests:
-            memory: "1024Mi"
-            cpu: "375m"
+            memory: "850Mi"
+            cpu: "175m"
           limits:
-            memory: "1500Mi"
-            cpu: "400m"
+            memory: "1024Mi"
+            cpu: "225m"
         ports:
         - containerPort: 8082
         env:

--- a/k8s/microservices/tracking.yml
+++ b/k8s/microservices/tracking.yml
@@ -18,11 +18,11 @@ spec:
         image: 'may24devopscontainers.azurecr.io/project-registry-tracking-microservice:0.0.1-SNAPSHOT'
         resources:
           requests:
-            memory: "900Mi"
-            cpu: "375m"
+            memory: "850Mi"
+            cpu: "175m"
           limits:
-            memory: "1100Mi"
-            cpu: "400m"
+            memory: "1024Mi"
+            cpu: "200m"
         ports:
         - containerPort: 8083
         env:


### PR DESCRIPTION
resources:
          requests:
            memory: "1024Mi" -- >   850Mi
            cpu: "375m"  -- > 175m
          limits:
            memory: "1500Mi" --> 1024Mi
            cpu: "400m" --> 200m

For all microservices.